### PR TITLE
Implement reusable modal system with stack support

### DIFF
--- a/src/components/LogOutModal/LogOutModal.jsx
+++ b/src/components/LogOutModal/LogOutModal.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const LogOutModal = () => {
+  return <div>LogOutModal</div>;
+};
+
+export default LogOutModal;

--- a/src/components/SharedLayout/SharedLayout.jsx
+++ b/src/components/SharedLayout/SharedLayout.jsx
@@ -1,11 +1,13 @@
 import { Suspense } from "react";
 import Header from "../Header/Header";
+import ModalRoot from "../UI/ModalRoot/ModalRoot";
 
 const SharedLayout = ({ children }) => {
   return (
     <>
       <Header />
       <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
+      <ModalRoot />
     </>
   );
 };

--- a/src/components/UI/Backdrop/Backdrop.jsx
+++ b/src/components/UI/Backdrop/Backdrop.jsx
@@ -1,19 +1,75 @@
+import { useEffect } from "react";
 import styles from "./Backdrop.module.css";
+import Icon from "../Icon/Icon";
 
 /**
- * Backdrop — a simple full-screen dimmed background for modals.
+ * Backdrop — універсальний напівпрозорий фон для модальних вікон або попапів.
  *
- * It does not handle closing logic (click or Escape).
- * Use it to wrap modal content and handle closing inside the content itself.
+ * Призначення:
+ * - Покриває весь екран та центрує контент
+ * - Закриває вікно при натисканні Escape (якщо передано onClose)
+ * - Закриває при кліку на фон (за межами контенту)
  *
- * Example:
- * <Backdrop>
- *   <ModalContent onClose={...} />
+ * Як використовувати:
+ * <Backdrop onClose={handleClose}>
+ *   <MyModal />
  * </Backdrop>
+ *
+ * Пропси:
+ * @param {function} [onClose] — функція закриття модалки
+ * @param {React.ReactNode} children — вміст модального вікна
+ * @param {number} [zIndex=1000] — z-index для стекування (можна використовувати в системі модалок)
+ *
+ * Примітки:
+ * - Подія кліку всередині вікна не закриває модалку (stopPropagation)
+ * - Може використовуватись як окремий компонент або як частина ModalRoot
  */
 
-const Backdrop = ({ children }) => {
-  return <div className={styles.backdrop}>{children}</div>;
+/**
+ * Backdrop — a reusable full-screen dimmed overlay for modals or popups.
+ *
+ * Purpose:
+ * - Covers the entire screen and centers the content
+ * - Closes on Escape key press (if onClose is provided)
+ * - Closes on backdrop click (outside the modal content)
+ *
+ * Usage example:
+ * <Backdrop onClose={handleClose}>
+ *   <MyModal />
+ * </Backdrop>
+ *
+ * Props:
+ * @param {function} [onClose] — callback to close the modal
+ * @param {React.ReactNode} children — content inside the modal
+ * @param {number} [zIndex=1000] — optional stacking order (useful in modal stacks)
+ *
+ * Notes:
+ * - Internal clicks are protected with stopPropagation
+ * - Can be used standalone or inside a modal system like ModalRoot
+ */
+
+const Backdrop = ({ children, onClose, zIndex = 1000 }) => {
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === "Escape" && typeof onClose === "function") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleEsc);
+    return () => {
+      removeEventListener("keydown", handleEsc);
+    };
+  }, [onClose]);
+  return (
+    <div className={styles.backdrop} onClick={onClose} style={{ zIndex }}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <button className={styles.closeButton} onClick={onClose}>
+          <Icon className={styles.icon} name="close" size={20} />
+        </button>
+        {children}
+      </div>
+    </div>
+  );
 };
 
 export default Backdrop;

--- a/src/components/UI/Backdrop/Backdrop.module.css
+++ b/src/components/UI/Backdrop/Backdrop.module.css
@@ -10,3 +10,26 @@
   align-items: center;
   justify-content: center;
 }
+
+.modalContent {
+  position: relative;
+  z-index: 1001;
+}
+
+.closeButton {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 1002;
+  background: none;
+  border: none;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+@media only screen and (min-width: 768px) {
+  .icon {
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/src/components/UI/Button/Button.jsx
+++ b/src/components/UI/Button/Button.jsx
@@ -26,6 +26,7 @@ const Button = ({
   ariaLabel,
   children,
   fullWidth,
+  ...props
 }) => {
   return (
     <button
@@ -38,6 +39,7 @@ const Button = ({
         styles[variant],
         fullWidth && styles.fullWidth
       )}
+      {...props}
     >
       <span className={styles.content} style={{ gap }}>
         {children}

--- a/src/components/UI/Icon/Icon.jsx
+++ b/src/components/UI/Icon/Icon.jsx
@@ -1,4 +1,30 @@
 import icon from "../../../assets/icons/sprite.svg";
+
+/**
+ * Компонент Icon — універсальний рендерер SVG-іконок.
+ *
+ * Використовує спрайт з `../../assets/icons/sprite.svg` для відображення іконок за їхнім ID.
+ * Дозволяє налаштовувати розмір, заповнення (fill), обведення (stroke) та додаткові CSS класи.
+ *
+ * Пропси:
+ * - `name` (string, за замовчуванням: "logo") — ID іконки у спрайті (наприклад: "burger-menu", "error", "check" тощо).
+ * - `className` (string, необов’язково) — додаткові CSS класи.
+ * - `size` (number, за замовчуванням: 16) — ширина та висота іконки у пікселях.
+ * - `fill` (string, необов’язково) — колір заповнення SVG.
+ * - `stroke` (string, необов’язково) — колір обведення SVG.
+ *
+ * Приклад використання:
+ * ```jsx
+ * <Icon name="calendar" size={24} fill="#333" />
+ * <Icon name="chevron-down" className="rotate" stroke="#999" />
+ * ```
+ *
+ * Доступні ID іконок:
+ * "logo", "burger-menu", "error", "success", "arrow-down", "arrow-up", "calendar",
+ * "check", "chevron-down", "chevron-up", "clock", "close", "edit", "eye", "eye-off",
+ * "log-out", "user-avatar", "search", "trash", "user"
+ */
+
 /**
  * Icon component — a universal SVG icon renderer.
  *

--- a/src/components/UI/Icon/Icon.jsx
+++ b/src/components/UI/Icon/Icon.jsx
@@ -34,8 +34,7 @@ const Icon = ({
 }) => {
   return (
     <svg
-      classNam
-      e={className}
+      className={className}
       fill={fill}
       stroke={stroke}
       width={size}

--- a/src/components/UI/ModalRoot/ModalRoot.jsx
+++ b/src/components/UI/ModalRoot/ModalRoot.jsx
@@ -1,0 +1,91 @@
+import { useDispatch, useSelector } from "react-redux";
+import { selectModalsStack } from "../../../redux/modal/selectors";
+import { closeModal } from "../../../redux/modal/slice";
+import modalMap from "./modalMap";
+import Backdrop from "../Backdrop/Backdrop";
+
+/**
+ * ModalRoot — глобальний рендерер стеку модальних вікон.
+ *
+ * Призначення:
+ * Рендерить усі модалки, що зберігаються у state.modal.modals[].
+ * Кожна модалка — це об’єкт з полями modalType (назва) і modalProps (додаткові дані).
+ * Лише верхня модалка реагує на Escape та клік по фону (через Backdrop).
+ *
+ * Як відкрити модалку:
+ * dispatch(openModal({ modalType: 'MyModal', modalProps: { id: 123, onClose: fn } }))
+ *
+ * Як закрити поточну (верхню) модалку:
+ * dispatch(closeModal())
+ *
+ * Як додати нову модалку:
+ * 1. Створи компонент, наприклад: MyModal.jsx
+ * 2. Додай його до файлу modalMap.js:
+ *    const modalMap = { ..., MyModal }
+ *
+ * Важливо:
+ * - Всі модалки мають бути зареєстровані в modalMap
+ * - ModalRoot має бути розміщений у SharedLayout або App (рекомендується)
+ * - Додаткові пропси передаються автоматично через {...modalProps}
+ */
+
+/**
+ * ModalRoot — global renderer for stacked modals.
+ *
+ * Purpose:
+ * Renders all modals stored in state.modal.modals[].
+ * Each modal is an object with modalType (name) and modalProps (custom data).
+ * Only the top modal responds to Escape key and backdrop click (via Backdrop).
+ *
+ * How to open a modal:
+ * dispatch(openModal({ modalType: 'MyModal', modalProps: { id: 123, onClose: fn } }))
+ *
+ * How to close the top modal:
+ * dispatch(closeModal())
+ *
+ * How to register a new modal:
+ * 1. Create a component, e.g., MyModal.jsx
+ * 2. Add it to modalMap.js:
+ *    const modalMap = { ..., MyModal }
+ *
+ * Notes:
+ * - All modals must be registered in modalMap
+ * - ModalRoot should be placed in SharedLayout or App (recommended)
+ * - Additional props are passed via {...modalProps}
+ */
+
+const ModalRoot = () => {
+  const dispatch = useDispatch();
+  const modals = useSelector(selectModalsStack);
+
+  if (modals.length === 0) return null;
+
+  return (
+    <>
+      {modals.map(({ modalType, modalProps }, index) => {
+        const ModalComponent = modalMap[modalType];
+        const isTop = index === modals.length - 1;
+        const handleClose = () => dispatch(closeModal());
+
+        return (
+          <Backdrop
+            key={index}
+            onClose={isTop ? handleClose : undefined}
+            zIndex={1000 + index}
+          >
+            <ModalComponent {...modalProps} />
+          </Backdrop>
+        );
+      })}
+    </>
+  );
+};
+
+export default ModalRoot;
+
+// For block content scroll. Add in App or SharedLayout(preferable)
+// const modalOpen = useSelector(hasOpenModal);
+
+// useEffect(() => {
+//   document.body.style.overflow = modalOpen ? "hidden" : "auto";
+// }, [modalOpen]);

--- a/src/components/UI/ModalRoot/modalMap.js
+++ b/src/components/UI/ModalRoot/modalMap.js
@@ -1,0 +1,46 @@
+/**
+ * modalMap — об'єкт відповідності між назвою модального вікна (modalType)
+ * та відповідним React-компонентом, який потрібно відрендерити.
+ *
+ * Використовується в ModalRoot для динамічного рендерингу модалок зі стеку.
+ *
+ * Як додати нову модалку:
+ * 1. Створи або імпортуй компонент, наприклад:
+ *    import MyModal from '../modals/MyModal';
+ * 2. Додай його у об'єкт нижче з унікальним ключем:
+ *    const modalMap = {
+ *      ...,
+ *      MyModal
+ *    };
+ *
+ * Важливо:
+ * - Ключ повинен відповідати полю `modalType` при виклику openModal()
+ * - Не додавай функції або обгортки — лише компоненти
+ */
+
+/**
+ * modalMap — maps modalType string keys to corresponding React components.
+ *
+ * Used inside ModalRoot to dynamically render modals from the stack.
+ *
+ * How to register a new modal:
+ * 1. Import your component:
+ *    import MyModal from '../modals/MyModal';
+ * 2. Add it to the map:
+ *    const modalMap = {
+ *      ...,
+ *      MyModal
+ *    };
+ *
+ * Notes:
+ * - The key must match the modalType used when calling openModal()
+ * - Only pass components — no functions or wrappers
+ */
+
+const modalMap = {
+  // ModalContentOne,
+  // ModalContentTwo,
+  // add other modals
+};
+
+export default modalMap;

--- a/src/redux/modal/selectors.js
+++ b/src/redux/modal/selectors.js
@@ -1,0 +1,3 @@
+export const selectModalsStack = (state) => state.modal.modals;
+
+export const hasOpenModal = (state) => state.modal.modals.length > 0;

--- a/src/redux/modal/slice.js
+++ b/src/redux/modal/slice.js
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  modals: [],
+};
+
+const modalSlice = createSlice({
+  name: "modal",
+  initialState,
+  reducers: {
+    openModal(state, action) {
+      state.modals.push({
+        modalType: action.payload.modalType,
+        modalProps: action.payload.modalProps || {},
+      });
+    },
+    closeModal(state) {
+      state.modals.pop();
+    },
+  },
+});
+
+export const { openModal, closeModal } = modalSlice.actions;
+
+export const modalReducer = modalSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -15,6 +15,7 @@ import { categoriesReducer } from "./categories/slice";
 import { filterReducer } from "./filter/slice";
 import { transactionsReducer } from "./transactions/slice";
 import { userReducer } from "./user/slice";
+import { modalReducer } from "./modal/slice";
 
 const persistConfig = {
   key: "token",
@@ -32,6 +33,7 @@ export const store = configureStore({
     categories: categoriesReducer,
     transactions: transactionsReducer,
     filter: filterReducer,
+    modal: modalReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({


### PR DESCRIPTION
This pull request introduces a reusable and extensible modal system based on Redux state management and a modal stack.

Included:
✅ Created modalSlice with openModal and closeModal reducers

✅ Added modalReducer to Redux store

✅ Implemented ModalRoot component that renders stacked modals

✅ Added modalMap.js for dynamic modal resolution

✅ Refactored Backdrop component to support z-index, Escape key handling, and standalone usage

✅ Mounted <ModalRoot /> inside SharedLayout

Features:
Stack-based modal rendering

Only the top modal reacts to Escape key and backdrop click

Simple modal registration via modalMap

External control of modals using modalProps (e.g. callbacks, data)

🔧 Ready for further integration with specific modal components